### PR TITLE
Update mysql.lua

### DIFF
--- a/drivers/mysql.lua
+++ b/drivers/mysql.lua
@@ -1,4 +1,3 @@
-local mysql = require'resty.mysql'
 local fun = require'orm.func'
 local assert = assert
 local ipairs = ipairs
@@ -10,6 +9,7 @@ local ngx_ctx = ngx.ctx
 
 local open = function(conf)
     local _connect = function()
+        local mysql = require'resty.mysql'
         local db, err = mysql:new()
         assert(not err, "failed to create: ", err)
 


### PR DESCRIPTION
> The resty.mysql object instance cannot be stored in a Lua variable at the Lua module level, because it will then be shared by all the concurrent requests handled by the same nginx worker process

[https://github.com/openresty/lua-resty-mysql#limitations](url)